### PR TITLE
Specify clang as default C/CXX compiler for llvm.BUILT target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ clean:
 build/llvm.BUILT:
 	mkdir -p build/llvm
 	cd build/llvm; cmake -G "Unix Makefiles" \
+		-DCMAKE_C_COMPILER=clang \
+		-DCMAKE_CXX_COMPILER=clang++ \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
 		-DCMAKE_INSTALL_PREFIX=$(PREFIX) \
 		-DLLVM_TARGETS_TO_BUILD=WebAssembly \


### PR DESCRIPTION
When trying to build from source, the build was failing at the first target `llvm.BUILT` around 28% mark with an internal compiler error. I've tracked it down to the fact that linux OS in Docker build-env was by default using an outdated `gcc`/`g++` rather than `clang`, even though the latter was installed. Anyhow, I've fixed it by manually specifying `clang` as the go-to compiler for the first build target.