### PR TITLE
Prefer https over ssh url for wasi-sysroot submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/llvm/llvm-project
 [submodule "src/wasi-sysroot"]
 	path = src/wasi-sysroot
-	url = git@github.com:CraneStation/wasi-sysroot
+	url = https://github.com/CraneStation/wasi-sysroot


### PR DESCRIPTION
To avoid some firewall complications https urls are recommend
over ssh:

https://help.github.com/en/articles/which-remote-url-should-i-use

also makes URL type for wasi-sysroot consistent with llvm-project.