### PR TITLE
Distribute updated config.sub and config.guess.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/wasi-sysroot"]
 	path = src/wasi-sysroot
 	url = https://github.com/CraneStation/wasi-sysroot
+[submodule "src/config"]
+	path = src/config
+	url = https://git.savannah.gnu.org/git/config.git

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,12 @@ build/libcxxabi.BUILT: build/libcxx.BUILT build/llvm.BUILT
 	mv $(PREFIX)/share/sysroot/lib/libc++abi.a $(PREFIX)/share/sysroot/lib/wasm32-wasi/
 	touch build/libcxxabi.BUILT
 
-build: build/llvm.BUILT build/wasi-sysroot.BUILT build/compiler-rt.BUILT build/libcxxabi.BUILT build/libcxx.BUILT
+build/config.BUILT:
+	mkdir -p $(PREFIX)/share/misc
+	cp src/config/config.sub src/config/config.guess $(PREFIX)/share/misc
+	touch build/config.BUILT
+
+build: build/llvm.BUILT build/wasi-sysroot.BUILT build/compiler-rt.BUILT build/libcxxabi.BUILT build/libcxx.BUILT build/config.BUILT
 
 strip: build/llvm.BUILT
 	cd $(PREFIX)/bin; strip clang-8 llc lld llvm-ar

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ builds configured to set the default target and sysroot for convenience.
 One could also use a standard Clang 8.0, build a sysroot from the sources
 mentioned above, and compile with
 "--target=wasm32-unknown-wasi --sysroot=/path/to/sysroot".
+
+## Notes for Autoconf
+
+Upstream autoconf now
+[recognizes WASI](http://lists.gnu.org/archive/html/config-patches/2019-04/msg00001.html).
+
+For convenience when building packages that aren't yet updated, updated
+config.sub and config.guess files are installed at share/misc/config.\*
+in the install directory.


### PR DESCRIPTION
Distribute versions of config.sub and config.guess with wasm and wasi
support.

Fixes #16.
