### PR TITLE
Rename sysroot to wasi-sysroot.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build/llvm.BUILT:
 		-DLLVM_EXTERNAL_CLANG_SOURCE_DIR=$(LLVM_PROJ_DIR)/clang \
 		-DLLVM_EXTERNAL_LLD_SOURCE_DIR=$(LLVM_PROJ_DIR)/lld \
 		-DLLVM_ENABLE_PROJECTS="lld;clang" \
-		-DDEFAULT_SYSROOT=$(PREFIX)/share/sysroot \
+		-DDEFAULT_SYSROOT=$(PREFIX)/share/wasi-sysroot \
 		$(LLVM_PROJ_DIR)/llvm
 	cd build/llvm; $(MAKE) -j 8 \
 		install-clang \
@@ -43,7 +43,7 @@ build/llvm.BUILT:
 build/wasi-libc.BUILT: build/llvm.BUILT
 	make -C $(ROOT_DIR)/src/wasi-libc \
 		WASM_CC=$(PREFIX)/bin/clang \
-		SYSROOT=$(PREFIX)/share/sysroot
+		SYSROOT=$(PREFIX)/share/wasi-sysroot
 	touch build/wasi-libc.BUILT
 
 build/compiler-rt.BUILT: build/llvm.BUILT
@@ -94,7 +94,7 @@ build/libcxx.BUILT: build/llvm.BUILT build/compiler-rt.BUILT build/wasi-libc.BUI
 		$(LLVM_PROJ_DIR)/libcxx
 	cd build/libcxx; make -j 8 install
 	# libc++abi.a doesn't do a multiarch install, so fix it up.
-	mv $(PREFIX)/share/sysroot/lib/libc++.a $(PREFIX)/share/sysroot/lib/wasm32-wasi/
+	mv $(PREFIX)/share/wasi-sysroot/lib/libc++.a $(PREFIX)/share/wasi-sysroot/lib/wasm32-wasi/
 	touch build/libcxx.BUILT
 
 build/libcxxabi.BUILT: build/libcxx.BUILT build/llvm.BUILT
@@ -115,18 +115,18 @@ build/libcxxabi.BUILT: build/libcxx.BUILT build/llvm.BUILT
 		-DLLVM_COMPILER_CHECKED=ON \
 		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
 		-DLIBCXXABI_LIBCXX_PATH=$(LLVM_PROJ_DIR)/libcxx \
-		-DLIBCXXABI_LIBCXX_INCLUDES=$(PREFIX)/share/sysroot/include/c++/v1 \
+		-DLIBCXXABI_LIBCXX_INCLUDES=$(PREFIX)/share/wasi-sysroot/include/c++/v1 \
 		-DLLVM_CONFIG_PATH=$(ROOT_DIR)/build/llvm/bin/llvm-config \
 		-DCMAKE_TOOLCHAIN_FILE=$(ROOT_DIR)/wasi-sdk.cmake \
 		-DWASI_SDK_PREFIX=$(PREFIX) \
-		-DCMAKE_C_FLAGS="$(DEBUG_PREFIX_MAP) -I$(PREFIX)/share/sysroot/include" \
-		-DCMAKE_CXX_FLAGS="$(DEBUG_PREFIX_MAP) -I$(PREFIX)/share/sysroot/include/c++/v1" \
+		-DCMAKE_C_FLAGS="$(DEBUG_PREFIX_MAP) -I$(PREFIX)/share/wasi-sysroot/include" \
+		-DCMAKE_CXX_FLAGS="$(DEBUG_PREFIX_MAP) -I$(PREFIX)/share/wasi-sysroot/include/c++/v1" \
 		-DUNIX:BOOL=ON \
 		--debug-trycompile \
 		$(LLVM_PROJ_DIR)/libcxxabi
 	cd build/libcxxabi; make -j 8 install
 	# libc++abi.a doesn't do a multiarch install, so fix it up.
-	mv $(PREFIX)/share/sysroot/lib/libc++abi.a $(PREFIX)/share/sysroot/lib/wasm32-wasi/
+	mv $(PREFIX)/share/wasi-sysroot/lib/libc++abi.a $(PREFIX)/share/wasi-sysroot/lib/wasm32-wasi/
 	touch build/libcxxabi.BUILT
 
 build/config.BUILT:

--- a/wasi-sdk.cmake
+++ b/wasi-sdk.cmake
@@ -18,8 +18,8 @@ set(CMAKE_C_FLAGS "-v" CACHE STRING "wasi-sdk build")
 set(CMAKE_CXX_FLAGS "-v -std=c++11" CACHE STRING "wasi-sdk build")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-threads" CACHE STRING "wasi-sdk build")
 
-set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/sysroot CACHE STRING "wasi-sdk build")
-set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/sysroot CACHE STRING "wasi-sdk build")
+set(CMAKE_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
+set(CMAKE_STAGING_PREFIX ${WASI_SDK_PREFIX}/share/wasi-sysroot CACHE STRING "wasi-sdk build")
 
 # Don't look in the sysroot for executables to run during the build
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
This renames /opt/wasi/share/sysroot to /opt/wasi/share/wasi-sysroot.

If the user selects an alternate prefix, this allows wasi-sysroot to
coexist with other packages with less risk of namespace collision. For
example, if the user uses a prefix of /usr/local, this avoids using
/usr/local/share/sysroot, which is fairly generic, and uses
/usr/local/share/wasi-sysroot, which more clearly indicates its purpose.