### PR TITLE
Update to the latest LLVM release/8.x release branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/llvm/llvm-project
+	branch = release/8.x
 [submodule "src/wasi-sysroot"]
 	path = src/wasi-sysroot
 	url = https://github.com/CraneStation/wasi-sysroot


### PR DESCRIPTION
This updates src/llvm-project to LLVM release/8.x:

https://github.com/llvm/llvm-project/tree/release/8.x/

This has some urgency as it includes the fix for the wasm-ld deadlock bug
which several users have run into:
 - https://reviews.llvm.org/D60757

As well as the fix for the long double va_arg bug:
 - https://reviews.llvm.org/D58656