### PR TITLE
Add Azure Pipelines definition for Linux and macOS

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,47 @@
+trigger:
+  - master
+
+jobs:
+- job: Build
+  timeoutInMinutes: 360
+  strategy:
+    matrix:
+      # windows:
+      #   imageName: 'vs2017-win2016'
+      mac:
+        imageName: 'macos-10.14'
+      linux:
+        imageName: 'ubuntu-16.04'
+
+  pool:
+    vmImage: $(imageName)
+
+  steps:
+    - bash: |
+        # Windows releases of LLVM don't include the llvm-nm tool, which is needed for building
+        # wasi-libc. Rust's llvm-tools include llvm-nm, and Rust is installed on Azure's Windows
+        # images, so we can use that to make llvm-nm available without too much overhead.
+        set -euo pipefail
+        rustup update stable
+        rustup default stable
+        rustup component add llvm-tools-preview
+        echo "##vso[task.setvariable variable=WASM_NM;]$(rustc --print sysroot|sed 's|C:|/c|'|sed 's|\\|/|g')/lib/rustlib/x86_64-pc-windows-msvc/bin/llvm-nm.exe"
+      displayName: Install llvm-nm (Windows)
+      condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
+    - script: |
+        choco install ninja
+      displayName: Install Ninja (Windows)
+      condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
+    - script: |
+        brew install ninja
+      displayName: Install Ninja (macOS)
+      condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
+    - script: |
+        sudo apt install ninja-build
+      displayName: Install Ninja (Linux)
+      condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+    - bash: |
+        set -euo pipefail
+        export PREFIX=`pwd`/out
+        make -j4
+      displayName: Build


### PR DESCRIPTION
This [passes on Linux and macOS](https://dev.azure.com/tschneidereit/WASI%20SDK/_build/results?buildId=88), but has Windows disabled for now, because I pwasn't able to get the build to work there](https://dev.azure.com/tschneidereit/WASI%20SDK/_build/results?buildId=87).

This definition only does the build, but doesn't actually publish it anywhere—we should do that as a follow-up.