### PR TITLE
Dockerfile: Use debian/stretch as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM ubuntu:xenial as build-env
+# Use a relatively old/stable distro here to maximize the supported platforms
+# and avoid depending on more recent version of, say, libc.
+FROM debian:stretch
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-	build-essential \
-	clang \
-	cmake \
-	python \
-	git \
-	ninja-build \
+        build-essential \
+        clang \
+        cmake \
+        python \
+        git \
+        ninja-build \
+ && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Ubuntu is based on debian and debian a more stable base to build on
IMHO.  This shouldn't effect much other than some minor changes in the
exact version clang we use to cross compile and the specific linked
host shared libraries.

Also, run `apt-get clean` to minimize image size (not that that really
matters since this is only used during SDK build).