### PR TITLE
Install strings, don't install libclang, and tidy up install rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,8 @@ build/llvm.BUILT:
 		$(LLVM_PROJ_DIR)/llvm
 	ninja -v -C build/llvm \
 		install-clang \
-		install-libclang \
-		install-libclang-headers \
 		install-clang-format \
 		install-clang-tidy \
-		install-clangQuery \
 		install-clang-apply-replacements \
 		install-lld \
 		install-llvm-ranlib \
@@ -50,8 +47,7 @@ build/llvm.BUILT:
 		install-strings \
 		install-objdump \
 		install-objcopy \
-		install-c++filt \
-		install-llvm-config
+		install-c++filt
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ build/llvm.BUILT:
 		install-strings \
 		install-objdump \
 		install-objcopy \
-		install-c++filt
+		install-c++filt \
+		llvm-config
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build/llvm.BUILT:
 	ninja -v -C build/llvm \
 		install-clang \
 		install-libclang \
+		install-libclang-headers \
 		install-clang-format \
 		install-clang-tidy \
 		install-clangQuery \

--- a/Makefile
+++ b/Makefile
@@ -37,25 +37,20 @@ build/llvm.BUILT:
 		install-clangQuery \
 		install-clang-apply-replacements \
 		install-lld \
-		install-llc \
-		install-llvm-ar \
 		install-llvm-ranlib \
 		install-llvm-strip \
 		install-llvm-dwarfdump \
 		$(if $(patsubst 8.%,,$(CLANG_VERSION)),install-clang-resource-headers,install-clang-headers) \
-		install-llvm-nm \
-		install-llvm-size \
-		install-llvm-objdump \
-		install-llvm-objcopy \
 		install-ar \
 		install-ranlib \
 		install-strip \
 		install-nm \
 		install-size \
+		install-strings \
 		install-objdump \
 		install-objcopy \
 		install-c++filt \
-		llvm-config
+		install-llvm-config
 	touch build/llvm.BUILT
 
 build/wasi-libc.BUILT: build/llvm.BUILT


### PR DESCRIPTION
Also remove redundant install-* rules. Also, don't install llc, since
it isn't an end-user tool.