### PR TITLE
Github Actions uploads built artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,6 @@ jobs:
         name: Build
       - uses: actions/upload-artifact@v1
         with:
-          name: ${{ format( 'packages-{0}.tgz', matrix.os) }}
+          # Upload the dist folder. Give it a name according to the OS it was built for.
+          name: ${{ format( 'dist-{0}.tgz', matrix.os) }}
           path: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,7 @@ jobs:
       - run: sudo make -j4 package
         shell: bash
         name: Build
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ format( 'packages-{0}.tgz', matrix.os) }}
+          path: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           # llvm 9 build is broken on windows for now. Re-enable this when it is fixed:
           # - windows-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           submodules: true
       - run: |

--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,11 @@ build: build/llvm.BUILT build/wasi-libc.BUILT build/compiler-rt.BUILT build/libc
 strip: build/llvm.BUILT
 	cd $(PREFIX)/bin; strip clang-9 lld llvm-ar
 
-package: build/package.BUILT
+package: dist
 
-build/package.BUILT: build strip
-	command -v dpkg-deb >/dev/null && ./deb_from_installation.sh || true
-	./tar_from_installation.sh
-	touch build/package.BUILT
+dist: build strip
+	mkdir -p dist
+	command -v dpkg-deb >/dev/null && ./deb_from_installation.sh $(shell pwd)/dist || true
+	./tar_from_installation.sh $(shell pwd)/dist
 
 .PHONY: default clean build strip package

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,6 @@ build/package.BUILT: build strip
 	mkdir -p dist
 	command -v dpkg-deb >/dev/null && ./deb_from_installation.sh $(shell pwd)/dist || true
 	./tar_from_installation.sh $(shell pwd)/dist
-	touch built/package.BUILT
+	touch build/package.BUILT
 
 .PHONY: default clean build strip package

--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,12 @@ build: build/llvm.BUILT build/wasi-libc.BUILT build/compiler-rt.BUILT build/libc
 strip: build/llvm.BUILT
 	cd $(PREFIX)/bin; strip clang-9 lld llvm-ar
 
-package: dist
+package: build/package.BUILT
 
-dist: build strip
+build/package.BUILT: build strip
 	mkdir -p dist
 	command -v dpkg-deb >/dev/null && ./deb_from_installation.sh $(shell pwd)/dist || true
 	./tar_from_installation.sh $(shell pwd)/dist
+	touch built/package.BUILT
 
 .PHONY: default clean build strip package

--- a/deb_from_installation.sh
+++ b/deb_from_installation.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env sh
 set -ex
 if [ -n "$1" ]; then
-	export VERSION="$1"
+    OUTDIR=$1
 else
-	export VERSION=`./version.sh`
+    OUTDIR=$PWD/build
+fi
+
+if [ -n "$2" ]; then
+    VERSION="$2"
+else
+    VERSION=`./version.sh`
 fi
 
 rm -rf build/pkg
@@ -12,3 +18,4 @@ mkdir -p build/pkg/DEBIAN
 sed -e s/VERSION/$VERSION/ wasi-sdk.control > build/pkg/DEBIAN/control
 cp -R /opt/wasi-sdk build/pkg/opt/
 cd build && dpkg-deb -b pkg wasi-sdk_$VERSION\_amd64.deb
+mv build/wasi-sdk_$VERSION\amd64.deb $OUTDIR/

--- a/deb_from_installation.sh
+++ b/deb_from_installation.sh
@@ -3,7 +3,7 @@ set -ex
 if [ -n "$1" ]; then
     OUTDIR=$1
 else
-    OUTDIR=$PWD/build
+    OUTDIR=$PWD/dist
 fi
 
 if [ -n "$2" ]; then

--- a/tar_from_installation.sh
+++ b/tar_from_installation.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 if [ -n "$1" ]; then
-    VERSION="$1"
+    OUTDIR=$1
+else
+    OUTDIR=$PWD/build
+fi
+
+if [ -n "$2" ]; then
+    VERSION="$2"
 else
     VERSION=`./version.sh`
 fi
@@ -19,10 +25,10 @@ esac
 rm -rf $PKGDIR
 cp -R /opt/wasi-sdk $PKGDIR
 cd build
-tar czf wasi-sdk-$VERSION\-$MACHINE.tar.gz wasi-sdk-$VERSION
+tar czf $OUTDIR/wasi-sdk-$VERSION\-$MACHINE.tar.gz wasi-sdk-$VERSION
 
 # As well as the full SDK package, also create archives of libclang_rt.builtins
 # and the sysroot. These are made available for users who have an existing clang
 # installation.
-tar czf libclang_rt.builtins-wasm32-wasi-$VERSION.tar.gz -C compiler-rt lib/wasi
-tar czf wasi-sysroot-$VERSION.tar.gz -C wasi-sdk-$VERSION/share wasi-sysroot
+tar czf $OUTDIR/libclang_rt.builtins-wasm32-wasi-$VERSION.tar.gz -C compiler-rt lib/wasi
+tar czf $OUTDIR/wasi-sysroot-$VERSION.tar.gz -C wasi-sdk-$VERSION/share wasi-sysroot

--- a/tar_from_installation.sh
+++ b/tar_from_installation.sh
@@ -3,7 +3,7 @@ set -ex
 if [ -n "$1" ]; then
     OUTDIR=$1
 else
-    OUTDIR=$PWD/build
+    OUTDIR=$PWD/dist
 fi
 
 if [ -n "$2" ]; then


### PR DESCRIPTION
This changes the build scripts to put the artifacts we use for releases in `dist/`, and has Github Actions upload those artifacts to Github.

I tried doing some yaml programming to automate putting those artifacts into a release, but I wasn't having a great time of it, but this should make it much easier to produce releases by manually downloading artifacts and then attaching them to a release, rather than build them locally.