### PR TITLE
github actions: pin checkout action to v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           # llvm 9 build is broken on windows for now. Re-enable this when it is fixed:
           # - windows-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           submodules: true
       - run: |


### PR DESCRIPTION
master now contains a new v2 beta version of this action that no longer
supports "submodules".   We can update to v2 later once it stabilizes.